### PR TITLE
Update id in the URL after changing the puzzle

### DIFF
--- a/display.js
+++ b/display.js
@@ -5,7 +5,7 @@ const { ChessBoard } = require("./chessboard/chessboard.js")
 const { problems }   = require("./problems.json")
 const random         = require("./random.js")
 const { enableScroll, disableScroll }   = require("./toggle-scrollbar.js")
-const url_parameters = new URI(window.location.href).search(true)
+let url_parameters = new URI(window.location.href).search(true)
 
 function unhighlight() {
   $("#board .square-55d63").css("background", "")
@@ -84,6 +84,10 @@ function next(problem=random.choice(problems)) {
     var problem_title = `${problem_type} - ${problem.first}`
     document.title = `#${problem.problemid}`
     if ("o" in url_parameters) { problem_title = `#${problem.problemid} ${problem_title}`}
+    if (history && history.pushState && url_parameters.id != problem.problemid) {
+        url_parameters.id = problem.problemid
+        history.pushState(url_parameters, "", new URI(window.location.href).search(url_parameters).toString())
+    }
     document.querySelector("#problem-title").innerHTML = problem_title
     document.querySelector("#problem-num").innerHTML = `${problem.problemid}`
     document.querySelector("#problem-link").href = "o" in url_parameters ? `?o&id=${problem.problemid}` : `?id=${problem.problemid}`
@@ -100,6 +104,11 @@ function next(problem=random.choice(problems)) {
 function init() {
     const problem = ("id" in url_parameters && url_parameters["id"] <= 4462 && url_parameters["id"] > 0) ? problems[url_parameters["id"] - 1] : random.choice(problems)
     next(problem)
+}
+
+window.onpopstate = function(event) {
+    url_parameters = event.state || url_parameters
+    init()
 }
 
 // Exports

--- a/display.js
+++ b/display.js
@@ -84,7 +84,7 @@ function next(problem=random.choice(problems)) {
     var problem_title = `${problem_type} - ${problem.first}`
     document.title = `#${problem.problemid}`
     if ("o" in url_parameters) { problem_title = `#${problem.problemid} ${problem_title}`}
-    if (history && history.pushState && url_parameters.id != problem.problemid) {
+    if (history && history.pushState && "o" in url_parameters && url_parameters.id != problem.problemid) {
         url_parameters.id = problem.problemid
         history.pushState(url_parameters, "", new URI(window.location.href).search(url_parameters).toString())
     }

--- a/display.js
+++ b/display.js
@@ -125,7 +125,7 @@ function pushstate() {
 
 window.onpopstate = function(event) {
     if (event.state) {
-        url_parameters = event.state
+        url_parameters["id"] = event.state["id"]
         next(problems[url_parameters["id"] - 1], false)
     }
 }

--- a/display.js
+++ b/display.js
@@ -66,7 +66,16 @@ const board = ChessBoard("board", {
             $("#next-btn").css("display", "")
             document.querySelector("#next-btn").onclick = function() {
                 const current_problem_id = document.querySelector("#problem-num").innerHTML;
-                ("o" in url_parameters && current_problem_id != 4462) ? next(problems[current_problem_id]) : next()
+                if ("o" in url_parameters && current_problem_id != 4462) {
+                    next(problems[current_problem_id])
+                    pushstate()
+                } else {
+                    next()
+                    if (history && history.replaceState && "id" in url_parameters) {
+                        delete url_parameters["id"]
+                        history.replaceState(url_parameters, "", new URI(window.location.href).search(url_parameters).toString())
+                    }
+                }
             }
             document.querySelector("#problem-title").innerHTML = document.querySelector("#problem-title").innerHTML.split("-")[0] + " - Solved!"
         }
@@ -77,22 +86,18 @@ const board = ChessBoard("board", {
     onSnapEnd: function() { board.position(game.fen()); unhighlight() }
 })
 
-function next(problem=random.choice(problems)) {
+function next(problem=random.choice(problems), useAnimation=true) {
     $("#next-btn").css("display", "none")
     $("#hint-btn").css("display", "")
     const problem_type = "Checkm" + problem.type.slice(1) + " Move" + (problem.type.endsWith("One") ? "" : "s")
     var problem_title = `${problem_type} - ${problem.first}`
     document.title = `#${problem.problemid}`
     if ("o" in url_parameters) { problem_title = `#${problem.problemid} ${problem_title}`}
-    if (history && history.pushState && "o" in url_parameters && url_parameters.id != problem.problemid) {
-        url_parameters.id = problem.problemid
-        history.pushState(url_parameters, "", new URI(window.location.href).search(url_parameters).toString())
-    }
     document.querySelector("#problem-title").innerHTML = problem_title
     document.querySelector("#problem-num").innerHTML = `${problem.problemid}`
     document.querySelector("#problem-link").href = "o" in url_parameters ? `?o&id=${problem.problemid}` : `?id=${problem.problemid}`
     game = new Chess(problem.fen)
-    board.position(problem.fen)
+    board.position(problem.fen, useAnimation)
     correct_moves = problem.moves.split(";")
     document.querySelector("#hint-btn").onclick = function() {
         let [source, target, promotion] = parse_move(correct_moves[0])
@@ -104,11 +109,25 @@ function next(problem=random.choice(problems)) {
 function init() {
     const problem = ("id" in url_parameters && url_parameters["id"] <= 4462 && url_parameters["id"] > 0) ? problems[url_parameters["id"] - 1] : random.choice(problems)
     next(problem)
+    pushstate()
+}
+
+function pushstate() {
+    if (history && history.pushState && "o" in url_parameters) {
+        const current_problem_id = document.querySelector("#problem-num").innerHTML
+        url_parameters["id"] = current_problem_id
+        if (history.state && history.state["id"] == current_problem_id) {
+            return
+        }
+        history.pushState(url_parameters, "", new URI(window.location.href).search(url_parameters).toString())
+    }
 }
 
 window.onpopstate = function(event) {
-    url_parameters = event.state || url_parameters
-    init()
+    if (event.state) {
+        url_parameters = event.state
+        next(problems[url_parameters["id"] - 1], false)
+    }
 }
 
 // Exports


### PR DESCRIPTION
Fixes #1.

This change calls [`history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) when the puzzles changes, to ensure that the `id` in the URL always matches the current puzzle.

This helps users avoid losing their place if they are working their way through the puzzles and need to restart Chrome.  It also means that users can use the browser's Back and Forward buttons to navigate through their puzzle history.
